### PR TITLE
fix(app-correios): Xml parsing fix to json

### DIFF
--- a/packages/apps/correios/lib-mjs/correios-ws.mjs
+++ b/packages/apps/correios/lib-mjs/correios-ws.mjs
@@ -27,7 +27,8 @@ const sendCalculateRequest = (params, timeout, isDebug = false) => {
   })
     .then(async (response) => {
       // parse XML to object
-      const result = await xml2js.parseStringPromise(response.data);
+      // https://www.npmjs.com/package/xml2js#options/
+      const result = await xml2js.parseStringPromise(response.data, { explicitArray: false });
       let services;
       if (Array.isArray(result.Servicos)) {
         services = result.Servicos;


### PR DESCRIPTION
O app tava com um bug no parse do `XML` para `Json`, onde a propriedade eram sempre convertidas para um `Array`

https://www.npmjs.com/package/xml2js#options
> explicitArray (default: true): Always put child nodes in an array if true; otherwise an array is created only if there is more than one.

Essa  alteração corrigiu o bug aqui nos meus testes locais 