### PR TITLE
refactor(cli): Update getToken for external oauth

### DIFF
--- a/packages/cli/src/setup-gcloud.ts
+++ b/packages/cli/src/setup-gcloud.ts
@@ -45,7 +45,7 @@ const requestApi = async (
   const { error } = data;
   if (error) {
     let msgErr = 'Unexpected error in request';
-    msgErr = error.message ? `code: ${error.code} - ${error.message}` : msgErr;
+    msgErr = error.message ? `Code: ${error.code} - ${error.message}` : msgErr;
     const err = new Error(msgErr);
     throw err;
   }


### PR DESCRIPTION
Criei um app em um repo externo para requisitar as credenciais https://github.com/wisley7l/cloud-commerce-auth-gcp

Caso seja esse o caminho e o repo acima não muito fora dos padrões e caso necessário migro ele para Ecomplus. 

Mudei um pouco a função `requestApi` já pensando na outra etapa para um setup mais programatico que o atual. 

