### PR TITLE
feat(cli,feeds): smart rewrites merge and generic xml handler

### DIFF
--- a/packages/apps/tiny-erp/src/integration/parsers/order-to-tiny.ts
+++ b/packages/apps/tiny-erp/src/integration/parsers/order-to-tiny.ts
@@ -83,6 +83,10 @@ export default async (order: Orders, appData) => {
     if (shippingAddress.name) {
       tinyOrder.endereco_entrega.nome_destinatario = shippingAddress.name.substring(0, 60);
     }
+    if (buyer && buyer.doc_number && buyer.doc_number.length <= 18) {
+      tinyOrder.endereco_entrega.cpf_cnpj = buyer.doc_number;
+      tinyOrder.endereco_entrega.tipo_pessoa = buyer.registry_type === 'j' ? 'J' : 'F';
+    }
   }
 
   if (order.items) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -80,11 +80,34 @@ const run = async () => {
         const baseFirebaseConfig = JSON.parse(
           fs.readFileSync(joinPath(baseConfigDir, 'firebase.json'), 'utf8'),
         );
-        const mergedConfig = deepmerge(baseFirebaseConfig, userFirebaseConfig);
-        fs.writeFileSync(
-          joinPath(pwd, 'firebase.json'),
-          JSON.stringify(mergedConfig, null, 2),
-        );
+        const userRewrites: Array<Record<string, any>> | undefined = userFirebaseConfig?.hosting?.rewrites;
+        if (Array.isArray(userRewrites) && Array.isArray(baseFirebaseConfig.hosting?.rewrites)) {
+          const { rewrites: _omit, ...hostingRest } = userFirebaseConfig.hosting as Record<string, any>;
+          const mergedConfig = deepmerge(baseFirebaseConfig, {
+            ...userFirebaseConfig,
+            hosting: hostingRest,
+          });
+          const mergedRewrites: Array<Record<string, any>> = [...baseFirebaseConfig.hosting.rewrites];
+          for (const userRewrite of userRewrites) {
+            const matchIdx = mergedRewrites.findIndex((r) => r.function === userRewrite.function);
+            if (matchIdx >= 0) {
+              mergedRewrites[matchIdx] = { ...mergedRewrites[matchIdx], ...userRewrite };
+            } else {
+              mergedRewrites.push(userRewrite);
+            }
+          }
+          mergedConfig.hosting.rewrites = mergedRewrites;
+          fs.writeFileSync(
+            joinPath(pwd, 'firebase.json'),
+            JSON.stringify(mergedConfig, null, 2),
+          );
+        } else {
+          const mergedConfig = deepmerge(baseFirebaseConfig, userFirebaseConfig);
+          fs.writeFileSync(
+            joinPath(pwd, 'firebase.json'),
+            JSON.stringify(mergedConfig, null, 2),
+          );
+        }
       }
     }
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -82,20 +82,21 @@ const run = async () => {
         );
         const userRewrites: Array<Record<string, any>> | undefined = userFirebaseConfig?.hosting?.rewrites;
         if (Array.isArray(userRewrites) && Array.isArray(baseFirebaseConfig.hosting?.rewrites)) {
-          const { rewrites: _omit, ...hostingRest } = userFirebaseConfig.hosting as Record<string, any>;
+          const hostingRest: Record<string, any> = { ...userFirebaseConfig.hosting };
+          delete hostingRest.rewrites;
           const mergedConfig = deepmerge(baseFirebaseConfig, {
             ...userFirebaseConfig,
             hosting: hostingRest,
           });
           const mergedRewrites: Array<Record<string, any>> = [...baseFirebaseConfig.hosting.rewrites];
-          for (const userRewrite of userRewrites) {
+          userRewrites.forEach((userRewrite) => {
             const matchIdx = mergedRewrites.findIndex((r) => r.function === userRewrite.function);
             if (matchIdx >= 0) {
               mergedRewrites[matchIdx] = { ...mergedRewrites[matchIdx], ...userRewrite };
             } else {
               mergedRewrites.push(userRewrite);
             }
-          }
+          });
           mergedConfig.hosting.rewrites = mergedRewrites;
           fs.writeFileSync(
             joinPath(pwd, 'firebase.json'),

--- a/packages/feeds/src/firebase/serve-feeds.ts
+++ b/packages/feeds/src/firebase/serve-feeds.ts
@@ -118,7 +118,7 @@ const serveFeeds = async (req: Request, res: Response) => {
         await proxyGithubApi(req, res);
         break;
       }
-      if (req.path.endsWith('.xml')) {
+      if (req.path.endsWith('/catalog.xml')) {
         await renderCatalog(req, res, products);
         break;
       }

--- a/packages/feeds/src/firebase/serve-feeds.ts
+++ b/packages/feeds/src/firebase/serve-feeds.ts
@@ -106,10 +106,6 @@ const serveFeeds = async (req: Request, res: Response) => {
     }
   }
   switch (req.path) {
-    case '/_feeds/catalog.xml':
-    case '/catalog.xml':
-      await renderCatalog(req, res, products);
-      break;
     case '/sitemap-catalog.xml':
       await renderSitemap(req, res, products);
       break;
@@ -120,6 +116,10 @@ const serveFeeds = async (req: Request, res: Response) => {
     default:
       if (req.path.includes('/repos/')) {
         await proxyGithubApi(req, res);
+        break;
+      }
+      if (req.path.endsWith('.xml')) {
+        await renderCatalog(req, res, products);
         break;
       }
       res.sendStatus(404);


### PR DESCRIPTION
CLI: when store conf/firebase.json defines a rewrite for a function already present in base config, the merge replaces that entry instead of appending a duplicate. Falls back to adding a new entry if function is not found in base rewrites.

Feeds: catalog handler now matches any .xml path (except sitemap), so store-specific routing prefixes work without code changes.