### PR TITLE
fix(mercadopago): Allow PF/PJ customers to pay with either CPF or CNPJ cards

### DIFF
--- a/packages/apps/mercadopago/assets/onload-expression.js
+++ b/packages/apps/mercadopago/assets/onload-expression.js
@@ -4,6 +4,9 @@
 
   window._mpHash = function (data) {
     return new Promise((resolve, reject) => {
+      if (data.doc) {
+        data = Object.assign({}, data, { doc: data.doc.replace(/\D/g, '') });
+      }
       window
         ._mpBrand(data.number)
         .then(() => {
@@ -122,8 +125,10 @@
       const $typeDoc = document.createElement('select');
       $typeDoc.setAttribute('data-checkout', 'docType');
       const $typeDocOption = document.createElement('option');
-      $typeDocOption.text = customer.registry_type === 'j' ? 'CNPJ' : 'CPF';
-      $typeDocOption.value = customer.registry_type === 'j' ? 'CNPJ' : 'CPF';
+      const _docNum = (mpParams.docNumber || '').replace(/\D/g, '');
+      const _docType = _docNum.length === 14 ? 'CNPJ' : 'CPF';
+      $typeDocOption.text = _docType;
+      $typeDocOption.value = _docType;
       $typeDocOption.setAttribute('selected', true);
       $typeDoc.add($typeDocOption);
 

--- a/packages/apps/mercadopago/src/mp-create-transaction.ts
+++ b/packages/apps/mercadopago/src/mp-create-transaction.ts
@@ -159,7 +159,7 @@ export default async (appData: AppModuleBody) => {
       first_name: payerOrBuyer.fullname.replace(/\s.*/, ''),
       last_name: payerOrBuyer.fullname.replace(/[^\s]+\s/, ''),
       identification: {
-        type: payerOrBuyer.registry_type === 'j' ? 'CNPJ' : 'CPF',
+        type: String(payerOrBuyer.doc_number).replace(/\D/g, '').length === 14 ? 'CNPJ' : 'CPF',
         number: String(payerOrBuyer.doc_number),
       },
     },


### PR DESCRIPTION

Clientes PJ (registry_type 'j') podem pagar com cartão pessoal (CPF) e clientes PF podem usar cartão corporativo (CNPJ). O tipo enviado ao Mercado Pago agora é derivado da contagem de dígitos do documento (11 = CPF, 14 = CNPJ) em vez do registry_type do cadastro, tanto na tokenização client-side quanto na criação da transação server-side.