### PR TITLE
Add anti-fraud rate limiting to checkout to prevent card storm attacks

### DIFF
--- a/packages/firebase/src/config.ts
+++ b/packages/firebase/src/config.ts
@@ -206,6 +206,8 @@ export type AntiFraudConfig = false | {
   ttlHours?: number;
 };
 
+export const checkoutRateLimitsCollection = 'checkoutRateLimits';
+
 export const config = _config as {
   get(): BaseConfig & typeof mergeConfig & {
     metafields: Record<string, any>;

--- a/packages/firebase/src/config.ts
+++ b/packages/firebase/src/config.ts
@@ -199,8 +199,18 @@ const mergeConfig = {
 };
 _config.set(mergeConfig);
 
+export type AntiFraudConfig = false | {
+  checkoutWindowMs?: number;
+  checkoutLimitAddr?: number;
+  checkoutLimitIp?: number;
+  ttlHours?: number;
+};
+
 export const config = _config as {
-  get(): BaseConfig & typeof mergeConfig & { metafields: Record<string, any> };
+  get(): BaseConfig & typeof mergeConfig & {
+    metafields: Record<string, any>;
+    checkoutAntiFraud?: AntiFraudConfig;
+  };
   // eslint-disable-next-line
   set(config: any): void;
 };

--- a/packages/firebase/src/handlers/clean-checkout-rate-limits.ts
+++ b/packages/firebase/src/handlers/clean-checkout-rate-limits.ts
@@ -1,0 +1,28 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { logger, checkoutRateLimitsCollection } from '../config';
+
+const BATCH_SIZE = 300;
+const MAX_BATCHES = 50;
+
+export default async () => {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  let totalDeleted = 0;
+  for (let batchNumber = 0; batchNumber < MAX_BATCHES; batchNumber += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const snapshot = await db.collection(checkoutRateLimitsCollection)
+      .where('expireAt', '<=', now)
+      .limit(BATCH_SIZE)
+      .get();
+    if (snapshot.empty) break;
+    const batch = db.batch();
+    snapshot.docs.forEach((doc) => batch.delete(doc.ref));
+    // eslint-disable-next-line no-await-in-loop
+    await batch.commit();
+    totalDeleted += snapshot.size;
+    if (snapshot.size < BATCH_SIZE) break;
+  }
+  if (totalDeleted) {
+    logger.info(`Cleaned ${totalDeleted} expired checkout rate limit docs`);
+  }
+};

--- a/packages/firebase/src/index.ts
+++ b/packages/firebase/src/index.ts
@@ -3,6 +3,7 @@
 import * as functions from 'firebase-functions/v1';
 import config from './config';
 import checkStoreEvents from './handlers/check-store-events';
+import cleanCheckoutRateLimits from './handlers/clean-checkout-rate-limits';
 
 const { httpsFunctionOptions: { region } } = config.get();
 
@@ -17,4 +18,10 @@ export const cronStoreEvents = functionBuilder.pubsub
   .schedule(process.env.CRONTAB_STORE_EVENTS || '* * * * *')
   .onRun(() => {
     return checkStoreEvents();
+  });
+
+export const cronCleanCheckoutRateLimits = functionBuilder.pubsub
+  .schedule(process.env.CRONTAB_CLEAN_CHECKOUT_RATE_LIMITS || '17 4 * * *')
+  .onRun(() => {
+    return cleanCheckoutRateLimits();
   });

--- a/packages/modules/src/firebase/antifraud-rate-limit.ts
+++ b/packages/modules/src/firebase/antifraud-rate-limit.ts
@@ -1,0 +1,74 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { logger, type AntiFraudConfig } from '@cloudcommerce/firebase/lib/config';
+
+const COLLECTION = 'checkout_rate_limits';
+
+const checkKey = async (
+  firestore: ReturnType<typeof getFirestore>,
+  key: string,
+  limit: number,
+  now: number,
+  checkoutWindowMs: number,
+  expireAt: Timestamp,
+): Promise<{ blocked: boolean; reason: string }> => {
+  const ref = firestore.collection(COLLECTION).doc(key);
+  let blocked = false;
+
+  await firestore.runTransaction(async (t) => {
+    const doc = await t.get(ref);
+    const data = doc.exists ? doc.data()! : { count: 0, windowStart: now };
+    const withinWindow = (now - data.windowStart) < checkoutWindowMs;
+    const count = withinWindow ? data.count + 1 : 1;
+    const windowStart = withinWindow ? data.windowStart : now;
+    t.set(ref, { count, windowStart, updatedAt: now, key, expireAt });
+    if (count > limit) blocked = true;
+  });
+
+  return { blocked, reason: key.startsWith('addr') ? 'address' : 'ip' };
+};
+
+export default async function antiFraudRateLimit(
+  req: { body: any; headers: Record<string, string | string[] | undefined>; ip: string },
+  options: Exclude<AntiFraudConfig, false> = {},
+): Promise<{ blocked: boolean; reason?: string }> {
+  const {
+    checkoutWindowMs = 10 * 60 * 1000,
+    checkoutLimitAddr = 10,
+    checkoutLimitIp = 20,
+    ttlHours = 24,
+  } = options;
+
+  try {
+    const firestore = getFirestore();
+    const now = Date.now();
+    const expireAt = Timestamp.fromMillis(now + ttlHours * 60 * 60 * 1000);
+
+    const forwardedFor = req.headers['x-forwarded-for'];
+    const realIp = (Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor || req.ip)
+      .split(',')[0].trim();
+
+    const to = req.body?.shipping?.to;
+    const zip = String(to?.zip || '').replace(/\D/g, '');
+    const number = String(to?.number || '');
+    const addrKey = zip && number ? `addr_${zip}_${number}` : null;
+    const ipKey = realIp ? `ip_${realIp.replace(/[.:]/g, '_')}` : null;
+
+    const checks: Array<{ key: string; limit: number }> = [];
+    if (addrKey) checks.push({ key: addrKey, limit: checkoutLimitAddr });
+    if (ipKey) checks.push({ key: ipKey, limit: checkoutLimitIp });
+
+    const results = await Promise.all(
+      checks.map(({ key, limit }) => checkKey(firestore, key, limit, now, checkoutWindowMs, expireAt)),
+    );
+
+    const hit = results.find((r) => r.blocked);
+    if (hit) {
+      logger.warn(`Checkout blocked by rate limit — reason: ${hit.reason}`);
+      return { blocked: true, reason: hit.reason };
+    }
+  } catch (err) {
+    logger.warn('Anti-fraud rate limit check failed, allowing checkout', { err });
+  }
+
+  return { blocked: false };
+}

--- a/packages/modules/src/firebase/antifraud-rate-limit.ts
+++ b/packages/modules/src/firebase/antifraud-rate-limit.ts
@@ -1,7 +1,17 @@
 import { getFirestore, Timestamp } from 'firebase-admin/firestore';
-import { logger, type AntiFraudConfig } from '@cloudcommerce/firebase/lib/config';
+import {
+  logger,
+  checkoutRateLimitsCollection as COLLECTION,
+  type AntiFraudConfig,
+} from '@cloudcommerce/firebase/lib/config';
 
-const COLLECTION = 'checkout_rate_limits';
+const firstHeader = (
+  headers: Record<string, string | string[] | undefined>,
+  name: string,
+) => {
+  const value = headers[name];
+  return Array.isArray(value) ? value[0] : value;
+};
 
 const checkKey = async (
   firestore: ReturnType<typeof getFirestore>,
@@ -20,7 +30,9 @@ const checkKey = async (
     const withinWindow = (now - data.windowStart) < checkoutWindowMs;
     const count = withinWindow ? data.count + 1 : 1;
     const windowStart = withinWindow ? data.windowStart : now;
-    t.set(ref, { count, windowStart, updatedAt: now, key, expireAt });
+    t.set(ref, {
+      count, windowStart, updatedAt: now, key, expireAt,
+    });
     if (count > limit) blocked = true;
   });
 
@@ -28,13 +40,13 @@ const checkKey = async (
 };
 
 export default async function antiFraudRateLimit(
-  req: { body: any; headers: Record<string, string | string[] | undefined>; ip: string },
+  req: { body: any; headers: Record<string, string | string[] | undefined>; ip?: string },
   options: Exclude<AntiFraudConfig, false> = {},
 ): Promise<{ blocked: boolean; reason?: string }> {
   const {
     checkoutWindowMs = 10 * 60 * 1000,
     checkoutLimitAddr = 10,
-    checkoutLimitIp = 20,
+    checkoutLimitIp = 10,
     ttlHours = 24,
   } = options;
 
@@ -43,9 +55,13 @@ export default async function antiFraudRateLimit(
     const now = Date.now();
     const expireAt = Timestamp.fromMillis(now + ttlHours * 60 * 60 * 1000);
 
-    const forwardedFor = req.headers['x-forwarded-for'];
-    const realIp = (Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor || req.ip)
-      .split(',')[0].trim();
+    // Client IP may pass through CDN layers; mirror the SSR header chain,
+    // preferring edge-set headers over the spoofable X-Forwarded-For.
+    const ipsHeader = firstHeader(req.headers, 'x-real-ip')
+      || firstHeader(req.headers, 'x-forwarded-for')
+      || firstHeader(req.headers, 'cf-connecting-ip')
+      || firstHeader(req.headers, 'fastly-client-ip');
+    const realIp = (ipsHeader?.split(',')[0] || req.ip)?.trim() || '';
 
     const to = req.body?.shipping?.to;
     const zip = String(to?.zip || '').replace(/\D/g, '');
@@ -58,7 +74,9 @@ export default async function antiFraudRateLimit(
     if (ipKey) checks.push({ key: ipKey, limit: checkoutLimitIp });
 
     const results = await Promise.all(
-      checks.map(({ key, limit }) => checkKey(firestore, key, limit, now, checkoutWindowMs, expireAt)),
+      checks.map(({ key, limit }) => {
+        return checkKey(firestore, key, limit, now, checkoutWindowMs, expireAt);
+      }),
     );
 
     const hit = results.find((r) => r.blocked);

--- a/packages/modules/src/firebase/serve-modules-api.ts
+++ b/packages/modules/src/firebase/serve-modules-api.ts
@@ -1,8 +1,8 @@
 import type { Request, Response } from 'firebase-functions/v1';
+import config, { logger } from '@cloudcommerce/firebase/lib/config';
 import { schemas } from '../index';
 import handleModule from './handle-module';
 import checkout from './checkout';
-import config from '@cloudcommerce/firebase/lib/config';
 import antiFraudRateLimit from './antifraud-rate-limit.js';
 
 export default async (req: Request, res: Response) => {
@@ -42,10 +42,15 @@ export default async (req: Request, res: Response) => {
       }
       const { checkoutAntiFraud } = config.get();
       if (checkoutAntiFraud !== false) {
-        const { blocked } = await antiFraudRateLimit(
-          req,
-          typeof checkoutAntiFraud === 'object' ? checkoutAntiFraud : {},
-        );
+        let blocked = false;
+        try {
+          ({ blocked } = await antiFraudRateLimit(
+            req,
+            typeof checkoutAntiFraud === 'object' ? checkoutAntiFraud : {},
+          ));
+        } catch (err) {
+          logger.warn('Anti-fraud guard threw, allowing checkout', { err });
+        }
         if (blocked) {
           return res.status(429).json({
             error_code: 'CKT429',

--- a/packages/modules/src/firebase/serve-modules-api.ts
+++ b/packages/modules/src/firebase/serve-modules-api.ts
@@ -2,8 +2,10 @@ import type { Request, Response } from 'firebase-functions/v1';
 import { schemas } from '../index';
 import handleModule from './handle-module';
 import checkout from './checkout';
+import config from '@cloudcommerce/firebase/lib/config';
+import antiFraudRateLimit from './antifraud-rate-limit.js';
 
-export default (req: Request, res: Response) => {
+export default async (req: Request, res: Response) => {
   const { method } = req;
   if (method !== 'POST' && method !== 'GET') {
     return res.sendStatus(405);
@@ -38,6 +40,20 @@ export default (req: Request, res: Response) => {
             message: 'GET is acceptable only to JSON schema, at /@checkout/schema',
           });
       }
+      const { checkoutAntiFraud } = config.get();
+      if (checkoutAntiFraud !== false) {
+        const { blocked } = await antiFraudRateLimit(
+          req,
+          typeof checkoutAntiFraud === 'object' ? checkoutAntiFraud : {},
+        );
+        if (blocked) {
+          return res.status(429).json({
+            error_code: 'CKT429',
+            message: 'Too many checkout attempts. Try again later.',
+          });
+        }
+      }
+
       return checkout(req, res);
     }
     if (url === '/@checkout/schema') {


### PR DESCRIPTION
Firestore-backed sliding window rate limiter keyed by delivery address (CEP+number) and real client IP (via X-Forwarded-For). Blocks after 10 attempts per address or 20 per IP within 10 minutes. Returns HTTP 429 before any order or email is created. Firestore docs expire automatically via TTL field. Fails open on Firestore errors.

After deploy TTL will be enabled on Firestore for the checkout_rate_limits collection