### PR TITLE
feat(analytics): Adapting Awin conversion tracking data and add fallback pixel

### DIFF
--- a/packages/ssr/src/lib/analytics/send-to-awin.ts
+++ b/packages/ssr/src/lib/analytics/send-to-awin.ts
@@ -1,8 +1,8 @@
 import type { AnalyticsEvent } from './send-analytics-events';
-import { logger } from '@cloudcommerce/firebase/lib/config';
+import config, { logger } from '@cloudcommerce/firebase/lib/config';
 import axios from 'axios';
 
-// https://developer.awin.com/apidocs/conversion-api
+// https://help.awin.com/apidocs/conversion-api
 const {
   AWIN_ADVERTISER_ID,
   AWIN_API_KEY,
@@ -17,6 +17,16 @@ const awinAxios = AWIN_ADVERTISER_ID && AWIN_API_KEY
     },
   })
   : null;
+
+// https://help.awin.com/apidocs/conversion-api - accepted "channel" values
+const validChannels = new Set([
+  'aw', 'ppcgeneric', 'ppcbrand', 'display', 'social', 'Other', 'Organic', 'direct',
+]);
+
+// Awin forbids the pipe character in id/name/sku/category basket fields
+const stripPipes = (value: unknown) => (
+  typeof value === 'string' ? value.replace(/\|/g, '') : value
+);
 
 const sendToAwin = async ({
   events,
@@ -36,23 +46,23 @@ const sendToAwin = async ({
     const voucher = params.coupon;
     const awinOrder: Record<string, any> = {
       orderReference: params.transaction_id,
-      channel,
+      channel: validChannels.has(channel) ? channel : 'aw',
       awc,
       voucher,
       amount: params.value,
-      currency: params.currency || 'BRL',
+      currency: params.currency || config.get().currency,
       commissionGroups: [{
         code: 'DEFAULT',
         amount: params.value,
       }],
       basket: params.items?.map((item: Record<string, any>) => ({
-        id: item.object_id || item.item_id,
-        name: item.item_name,
+        id: stripPipes(item.object_id || item.item_id),
+        name: stripPipes(item.item_name),
         price: item.price,
         quantity: item.quantity || 1,
         commissionGroupCode: 'DEFAULT',
-        sku: item.item_id,
-        category: item.category || item.item_brand || item.item_id,
+        sku: stripPipes(item.item_id),
+        category: stripPipes(item.item_category || item.item_brand || item.item_id),
       })),
     };
     awinOrders.push(awinOrder);

--- a/packages/storefront/client.d.ts
+++ b/packages/storefront/client.d.ts
@@ -34,6 +34,7 @@ interface Window {
   GTAG_TAG_ID?: string;
   GA_TRACKING_ID?: string;
   GOOGLE_ADS_ID?: string;
+  AWIN_ADVERTISER_ID?: string;
   CMS_CUSTOM_CONFIG?: Record<string, any>;
   CMS_SSO_URL?: string | null;
   CMS_REPO_BASE_DIR?: string;

--- a/packages/storefront/src/lib/layouts/BaseHead.astro
+++ b/packages/storefront/src/lib/layouts/BaseHead.astro
@@ -94,6 +94,7 @@ window.ECOM_COUNTRY_CODE = '${countryCode}';
 window.GIT_BRANCH = '${import.meta.env.GIT_BRANCH || ''}';
 window.GIT_REPO = '${import.meta.env.GIT_REPO || import.meta.env.GITHUB_REPO || ''}';
 window.GCLOUD_PROJECT = '${import.meta.env.GCLOUD_PROJECT || ''}';
+window.AWIN_ADVERTISER_ID = '${import.meta.env.AWIN_ADVERTISER_ID || ''}';
 window.$storefront = ${JSON.stringify({ settings, data: {} })};`;
 if (apiContext.error) {
   const { message, statusCode } = apiContext.error;

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -26,8 +26,24 @@ import {
   isAuthReady,
 } from '@@sf/state/customer-session';
 import { shoppingCart } from '@@sf/state/shopping-cart';
-import { emitGtagEvent, getGtagItem } from '@@sf/state/use-analytics';
+import { emitGtagEvent, getGtagItem, trackingIds } from '@@sf/state/use-analytics';
 import utm from '@@sf/scripts/session-utm';
+
+// https://help.awin.com/apidocs - fallback pixel, redundant to the server-to-server
+// Conversion API call already made from send-to-awin.ts
+const emitAwinFallbackPixel = (orderId: string, amount: number, coupon?: string) => {
+  if (!window.AWIN_ADVERTISER_ID || !trackingIds.awc) return;
+  const src = 'https://www.awin1.com/sread.img'
+    + `?tt=ns&tv=2&merchant=${encodeURIComponent(window.AWIN_ADVERTISER_ID)}`
+    + `&amount=${amount}&cr=${encodeURIComponent(window.ECOM_CURRENCY)}`
+    + `&ref=${encodeURIComponent(orderId)}`
+    + `&parts=${encodeURIComponent(`DEFAULT:${amount}`)}`
+    + `&vc=${encodeURIComponent(coupon || '')}`
+    + `&ch=${encodeURIComponent(trackingIds.awin_channel || 'aw')}`
+    + '&testmode=0';
+  const img = new Image(0, 0);
+  img.src = src;
+};
 
 const watchAppRoutes = () => {
   const router = (window as any).storefrontApp?.router;
@@ -140,6 +156,7 @@ const watchAppRoutes = () => {
             params.shipping_delivery_days = days;
           }
           emitGtagEvent('purchase', params, paramsToHash);
+          emitAwinFallbackPixel(orderId, params.value as number, params.coupon);
           localStorage.setItem('gtag.orderIdSent', orderId);
         }
         isPurchaseSent = true;


### PR DESCRIPTION
- send-to-awin.ts: use the store's real currency instead of a hardcoded BRL fallback, fix a bug where product category was never actually sent (wrong field name), validate traffic channel against Awin's accepted values, and sanitize basket fields against forbidden pipe characters
- Add a client-side fallback conversion pixel, redundant to the existing server-to-server call, per Awin's tracking policy (packages/storefront)
- Expose the Awin advertiser ID to the storefront client for the pixel