### PR TITLE
fix(storefront): Refresh passport token before loading checkout app when near expiry

### DIFF
--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -321,6 +321,10 @@ if (!import.meta.env.SSR) {
       resolve(getAuth());
     });
   });
+  const storedTokenExpiresAt = session.auth ? new Date(session.auth.expires).getTime() : 0;
+  const storedTokenNeedsRefresh = storedTokenExpiresAt > 0
+    && storedTokenExpiresAt - Date.now() <= 10 * 1000;
+  const rejectAfter = (ms: number) => new Promise<never>((_, reject) => { setTimeout(() => reject(new Error('timeout')), ms); });
   if (window.location.hash.includes('account')) {
     initializingAuth
       .then(async (firebaseAuth) => {
@@ -337,6 +341,23 @@ if (!import.meta.env.SSR) {
         console.error(err);
         loadAppScript();
       });
+  } else if (storedTokenNeedsRefresh) {
+    Promise.race([initializingAuth, rejectAfter(10000)])
+      .then(async (firebaseAuth) => {
+        await Promise.race([firebaseAuth.authStateReady(), rejectAfter(5000)]);
+        if (!isAuthReady.value) {
+          await Promise.race([
+            new Promise<void>((res) => {
+              const u = watch(isAuthReady, (v) => {
+                if (v) { u(); res(); }
+              });
+            }),
+            rejectAfter(5000),
+          ]);
+        }
+        loadAppScript();
+      })
+      .catch(() => loadAppScript());
   } else {
     loadAppScript();
   }

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -321,10 +321,6 @@ if (!import.meta.env.SSR) {
       resolve(getAuth());
     });
   });
-  const storedTokenExpiresAt = session.auth ? new Date(session.auth.expires).getTime() : 0;
-  const storedTokenNeedsRefresh = storedTokenExpiresAt > 0
-    && storedTokenExpiresAt - Date.now() <= 10 * 1000;
-  const rejectAfter = (ms: number) => new Promise<never>((_, reject) => { setTimeout(() => reject(new Error('timeout')), ms); });
   if (window.location.hash.includes('account')) {
     initializingAuth
       .then(async (firebaseAuth) => {
@@ -341,23 +337,24 @@ if (!import.meta.env.SSR) {
         console.error(err);
         loadAppScript();
       });
-  } else if (storedTokenNeedsRefresh) {
-    Promise.race([initializingAuth, rejectAfter(10000)])
-      .then(async (firebaseAuth) => {
-        await Promise.race([firebaseAuth.authStateReady(), rejectAfter(5000)]);
-        if (!isAuthReady.value) {
-          await Promise.race([
-            new Promise<void>((res) => {
-              const u = watch(isAuthReady, (v) => {
-                if (v) { u(); res(); }
-              });
-            }),
-            rejectAfter(5000),
-          ]);
-        }
-        loadAppScript();
-      })
-      .catch(() => loadAppScript());
+  } else if (session.auth && !isAuthenticated.value) {
+    // Stored passport token is stale: wait for Firebase auth to renew it
+    // before app.js starts fetching with it
+    const waitingTokenRefresh = initializingAuth.then(async (firebaseAuth) => {
+      await firebaseAuth.authStateReady();
+      if (isAuthReady.value) return;
+      await new Promise<void>((resolve) => {
+        const unwatch = watch(isAuthReady, (ready) => {
+          if (!ready) return;
+          unwatch();
+          resolve();
+        });
+      });
+    });
+    Promise.race([
+      waitingTokenRefresh.catch(console.error),
+      new Promise((resolve) => { setTimeout(resolve, 10000); }),
+    ]).then(() => loadAppScript());
   } else {
     loadAppScript();
   }

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -274,7 +274,7 @@ if (!import.meta.env.SSR) {
     const appScript = document.createElement('script');
     appScript.src = src
       || (window as any)._appScriptSrc
-      || 'https://cdn.jsdelivr.net/npm/@ecomplus/storefront-app@2.0.0-beta.227/dist/lib/js/app.js';
+      || 'https://cdn.jsdelivr.net/npm/@ecomplus/storefront-app@2.0.0-beta.228/dist/lib/js/app.js';
     appScript.onload = () => {
       setTimeout(() => {
         watchAppRoutes();


### PR DESCRIPTION
When a recurring customer opens checkout with a stored passport token already expired or within the 10-second `isAuthenticated` margin, the storefront-app would load with the stale token, causing fetchCustomer to 401 and leaving the user stuck on the "Complete seu cadastro" screen instead of the login or checkout step.

Now checks synchronously if the stored token is stale before loading app.js and waits (up to a 10s overall cap) for Firebase auth to renew it via `/_api/passport/token`. All other users — new, anonymous, or with a valid token — load immediately with no change in behavior.

Also updates `@ecomplus/storefront-app` to 2.0.0-beta.228, whose account.js retries fetchCustomer on the ecomPassport `login` event (ecomplus/storefront#1298) — the client-side complement of this gate.