### PR TITLE
fix(storefront): Persist awc as a cookie so it survives a new tab

### DIFF
--- a/packages/ssr/src/lib/analytics/send-to-awin.ts
+++ b/packages/ssr/src/lib/analytics/send-to-awin.ts
@@ -18,7 +18,7 @@ const awinAxios = AWIN_ADVERTISER_ID && AWIN_API_KEY
   })
   : null;
 
-// https://help.awin.com/apidocs/conversion-api - accepted "channel" values
+// Expected AwinChannelCookie values — Awin docs mandate 'aw' as the fallback
 const validChannels = new Set([
   'aw', 'ppcgeneric', 'ppcbrand', 'display', 'social', 'Other', 'Organic', 'direct',
 ]);

--- a/packages/storefront/src/analytics/set-tracking-ids.ts
+++ b/packages/storefront/src/analytics/set-tracking-ids.ts
@@ -51,8 +51,7 @@ export const getTrackingIds = (
       value = id;
       sessionStorage.setItem(`analytics_${key}`, id);
       if (key === 'awc') {
-        // Persist as a real cookie (not just sessionStorage) so it survives
-        // a manually-opened new tab, per Awin's "last click direto" scenario
+        // Awin prescribes an awc cookie; sessionStorage doesn't survive a manually-opened tab
         setCookie('awc', id, 30);
       }
     } else {

--- a/packages/storefront/src/analytics/set-tracking-ids.ts
+++ b/packages/storefront/src/analytics/set-tracking-ids.ts
@@ -1,3 +1,5 @@
+import { setCookie } from '@@sf/sf-lib';
+
 export type TrackingIds = {
   gclid?: string,
   g_client_id?: string,
@@ -48,6 +50,11 @@ export const getTrackingIds = (
     if (id) {
       value = id;
       sessionStorage.setItem(`analytics_${key}`, id);
+      if (key === 'awc') {
+        // Persist as a real cookie (not just sessionStorage) so it survives
+        // a manually-opened new tab, per Awin's "last click direto" scenario
+        setCookie('awc', id, 30);
+      }
     } else {
       value = sessionStorage.getItem(`analytics_${key}`) || undefined;
     }

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -29,8 +29,8 @@ import { shoppingCart } from '@@sf/state/shopping-cart';
 import { emitGtagEvent, getGtagItem, trackingIds } from '@@sf/state/use-analytics';
 import utm from '@@sf/scripts/session-utm';
 
-// https://help.awin.com/apidocs - fallback pixel, redundant to the server-to-server
-// Conversion API call already made from send-to-awin.ts
+// https://help.awin.com/developers/docs/fall-back-conversion-pixel
+// Awin prioritizes one tracking method per order ref, no double-count with the S2S call
 const emitAwinFallbackPixel = (orderId: string, amount: number, coupon?: string) => {
   if (!window.AWIN_ADVERTISER_ID || !trackingIds.awc) return;
   const src = 'https://www.awin1.com/sread.img'


### PR DESCRIPTION
Awin's own "last click direto" test scenario (affiliate click, then
open a fresh tab and navigate directly) was losing the awc value
because it was only ever stored in sessionStorage, which a manually
opened tab does not inherit. The fallback-cookie read logic already
existed but nothing wrote that cookie — now it does.