### PR TITLE
fix(storefront): Show cash discount price in product JSON-LD

### DIFF
--- a/packages/storefront/src/lib/layouts/BaseHead.astro
+++ b/packages/storefront/src/lib/layouts/BaseHead.astro
@@ -8,6 +8,7 @@ import {
   inStock as checkInStock,
 } from '@ecomplus/utils';
 import { i19searchProducts } from '@@i18n';
+import { getPriceWithDiscount } from '@@sf/composables/use-prices';
 
 // @ts-ignore
 const isPWA = pwaInfo !== false; // config/astro/mock-pwa-info.mjs
@@ -211,7 +212,10 @@ if (apiContext.resource === 'products' && apiContext.doc) {
       url: canonicalUrl,
       availability: `${(checkInStock(product) ? 'In' : 'OutOf')}Stock`,
       priceCurrency: settings.currency,
-      price: getPrice(product),
+      price: getPriceWithDiscount(
+        getPrice(product),
+        settings.modules?.list_payments?.discount_option || {},
+      ),
       itemCondition: 'http://schema.org/'
         + `${(product.condition !== 'new' ? 'Used' : 'New')}Condition`,
       seller: {


### PR DESCRIPTION
Product JSON-LD offers now apply the store's configured payment discount (settings.modules.list_payments.discount_option), reusing getPriceWithDiscount from use-prices. Falls back to the regular price when no discount is configured, so behavior is unchanged for stores that don't set it.