### PR TITLE
fix(storefront): Restore prerendered pages skipped since the JSON-LD price change

### DIFF
--- a/packages/storefront/src/helpers/prices.ts
+++ b/packages/storefront/src/helpers/prices.ts
@@ -1,0 +1,20 @@
+import type { ListPaymentsResponse } from '@cloudcommerce/types';
+
+export type DiscountOption = Exclude<ListPaymentsResponse['discount_option'], undefined>;
+
+// Kept free of runtime imports so `.astro` files can use it without pulling
+// the modules info state into the SSR entry, where it runs `$storefront.onLoad`
+// on module evaluation, before `ssr-context` has set the global up.
+export const getPriceWithDiscount = (price: number, discount: DiscountOption) => {
+  const { type, value } = discount;
+  if (!value || (discount.min_amount && price < discount.min_amount)) {
+    return price;
+  }
+  let priceWithDiscount: number;
+  if (type === 'percentage') {
+    priceWithDiscount = price * ((100 - value) / 100);
+  } else {
+    priceWithDiscount = price - value;
+  }
+  return priceWithDiscount > 0 ? priceWithDiscount : 0;
+};

--- a/packages/storefront/src/lib/composables/use-prices.ts
+++ b/packages/storefront/src/lib/composables/use-prices.ts
@@ -7,6 +7,7 @@ import {
   loyaltyPointsPrograms,
   availableExtraDiscount,
 } from '@@sf/state/modules-info';
+import { getPriceWithDiscount } from '../../helpers/prices';
 
 export type Props = {
   product?: Partial<Products> & { final_price?: number } &
@@ -21,22 +22,7 @@ export type Props = {
   loyaltyPointsProgram?: Exclude<ListPaymentsResponse['loyalty_points_programs'], undefined>['k'];
 }
 
-export const getPriceWithDiscount = (
-  price: number,
-  discount: Exclude<Props['discountOption'], undefined>,
-) => {
-  const { type, value } = discount;
-  if (!value || (discount.min_amount && price < discount.min_amount)) {
-    return price;
-  }
-  let priceWithDiscount: number;
-  if (type === 'percentage') {
-    priceWithDiscount = price * ((100 - value) / 100);
-  } else {
-    priceWithDiscount = price - value;
-  }
-  return priceWithDiscount > 0 ? priceWithDiscount : 0;
-};
+export { getPriceWithDiscount };
 
 const usePrices = (props: Props) => {
   const _product = computed(() => {

--- a/packages/storefront/src/lib/layouts/BaseHead.astro
+++ b/packages/storefront/src/lib/layouts/BaseHead.astro
@@ -8,7 +8,7 @@ import {
   inStock as checkInStock,
 } from '@ecomplus/utils';
 import { i19searchProducts } from '@@i18n';
-import { getPriceWithDiscount } from '@@sf/composables/use-prices';
+import { getPriceWithDiscount } from '../../helpers/prices';
 
 // @ts-ignore
 const isPWA = pwaInfo !== false; // config/astro/mock-pwa-info.mjs


### PR DESCRIPTION
## Problema

Desde #788 o `BaseHead.astro` importa `getPriceWithDiscount` de `@@sf/composables/use-prices`. Esse módulo importa `@@sf/state/modules-info`, que por sua vez importa `@@sf/scripts/modules-info-preset` — e o preset chama `global.$storefront.onLoad()` **na avaliação do módulo**, sem guard.

Como o `BaseHead` está no grafo de toda página, o preset passou a ser avaliado quando o Astro importa o entry SSR para gerar as páginas, antes do `ssr-context` ter atribuído `globalThis.$storefront`. Toda build de loja quebra o prerender:

```
functions/ssr/.cloudcommerce/sf-tmp-dist/chunks/Picture_CaVmcAdl.mjs:86
    global.$storefront.onLoad(() => {
TypeError: Cannot read properties of undefined (reading 'onLoad')
    at BuildPipeline.retrieveSsrEntry (astro/dist/core/build/pipeline.js:244)
...
mv: cannot stat './.cloudcommerce/sf-tmp-dist/~fallback/index.html': No such file or directory
mv: cannot stat './.cloudcommerce/sf-tmp-dist/index.html': No such file or directory
```

O deploy segue adiante, então o erro não derruba o CI — mas `index.html` e `~fallback/index.html` deixam de ser gerados desde a v2.62.0.

## Solução

`getPriceWithDiscount` é aritmética pura. Move para `src/helpers/prices.ts`, módulo folha cujo único import é de tipo, e reexporta de `use-prices` — `use-cart-sidebar` e `use-shipping-calculator` seguem importando de onde importavam.

Efeito colateral bem-vindo: o chunk SSR de cada página deixa de carregar Vue reactive, `mitt` e `afetch` à toa.

## Verificação

- Grafo de imports do `BaseHead` volta a ser o de antes do #788, mais o módulo folha (só `import type`).
- `pnpm build` do monorepo passa; eslint e commitlint passam.
- **Não reproduzi o crash de ponta a ponta**: o build do pacote `storefront` não chega no caminho que falha (sem `content/` nem config de loja), então o controle sem a correção sai idêntico. A reprodução real precisa de um build de loja com config, como o CI faz. Vale conferir numa loja antes do release.

## Fora do escopo

Duas coisas relacionadas que deixei de fora deste PR:

1. O `modules-info-preset` continua com efeito colateral no topo do módulo — qualquer `.astro` que toque nesse grafo quebra igual. O guard ingênuo troca o crash por um preset silenciosamente vazio, então merece issue própria.
2. O arredondamento do JSON-LD diverge do feed de catálogo em 1 centavo. `render-catalog.ts` usa `.toFixed(2)`, o `BaseHead` usa `Math.round(x*100)/100`; para `14.9 * 0.95 = 14.155` dá `14.15` vs `14.16`. Pega todo preço terminado em `,90` e o Google Merchant Center reprova como "preço divergente" — 26 de 134 produtos numa loja real.
