### PR TITLE
fix(storefront): Restore prerendered homepage and offline fallback on store builds

### DIFF
--- a/packages/storefront/src/lib/layouts/BaseHead.astro
+++ b/packages/storefront/src/lib/layouts/BaseHead.astro
@@ -8,7 +8,6 @@ import {
   inStock as checkInStock,
 } from '@ecomplus/utils';
 import { i19searchProducts } from '@@i18n';
-import { getPriceWithDiscount } from '@@sf/composables/use-prices';
 
 // @ts-ignore
 const isPWA = pwaInfo !== false; // config/astro/mock-pwa-info.mjs
@@ -201,10 +200,6 @@ const inlineJSONLdWebsite = JSON.stringify({
 let inlineJSONLdOffer: string | undefined;
 if (apiContext.resource === 'products' && apiContext.doc) {
   const product = apiContext.doc;
-  const offerPrice = getPriceWithDiscount(
-    getPrice(product),
-    settings.modules?.list_payments?.discount_option || {},
-  );
   const productJSONLd: Record<string, any> = {
     '@context': 'http://schema.org',
     '@type': 'Product',
@@ -216,7 +211,7 @@ if (apiContext.resource === 'products' && apiContext.doc) {
       url: canonicalUrl,
       availability: `${(checkInStock(product) ? 'In' : 'OutOf')}Stock`,
       priceCurrency: settings.currency,
-      price: Math.round(offerPrice * 100) / 100,
+      price: getPrice(product),
       itemCondition: 'http://schema.org/'
         + `${(product.condition !== 'new' ? 'Used' : 'New')}Condition`,
       seller: {

--- a/packages/storefront/src/lib/scripts/modules-info-preset.ts
+++ b/packages/storefront/src/lib/scripts/modules-info-preset.ts
@@ -1,3 +1,5 @@
+import { onStorefrontInit } from '../../init-emitter';
+
 type ModulesInfoPreset = typeof window.$storefront.modulesInfoPreset;
 
 const checkObjNotNull = (obj: { [k: string]: any }) => {
@@ -49,8 +51,12 @@ const getModulesInfoPreset = (settingsModules = globalThis.$storefront.settings.
 
 const loadingGlobalInfoPreset: Promise<ModulesInfoPreset> = new Promise((resolve) => {
   if (import.meta.env.SSR) {
-    global.$storefront.onLoad(() => {
-      resolve(getModulesInfoPreset());
+    // `ssr-context` may not have set the global up yet when this module is
+    // evaluated, depending on where the bundler places it in the SSR graph.
+    onStorefrontInit(() => {
+      global.$storefront.onLoad(() => {
+        resolve(getModulesInfoPreset());
+      });
     });
   } else {
     window.$storefront.modulesInfoPreset = getModulesInfoPreset();


### PR DESCRIPTION
Reverte #788 e blinda o `modules-info-preset` contra o mesmo tropeço. Alternativa ao #800.

## O build quebrado

`BaseHead.astro` passou a importar `getPriceWithDiscount` de `@@sf/composables/use-prices`, que puxa `@@sf/state/modules-info` → `@@sf/scripts/modules-info-preset`, e esse chama `global.$storefront.onLoad()` **na avaliação do módulo**. Como o `BaseHead` está no grafo de toda página, o preset passou a ser avaliado quando o Astro importa o entry SSR pra gerar as páginas, antes do `ssr-context` ter atribuído o global.

Resultado desde a v2.62.0: **`index.html` e `~fallback/index.html` deixaram de ser gerados em toda build de loja**. O deploy segue adiante, então o CI não acusa — só o fallback offline do PWA e o HTML pré-renderizado da home somem.

## Por que reverter e não só consertar o import

A feature não tem como estar certa. No servidor, `state/modules-info.ts` mantém todo o `fetchInfo()` dentro de `if (!import.meta.env.SSR)` — nem `list_payments` nem `apply_discount` são buscados. O `settings.modules.list_payments.discount_option` que o #788 lê é só o **preset do CMS**, uma cópia à mão da config do app que o `modules-info` sobrescreve no cliente assim que o módulo real responde.

E o desconto async fica de fora por completo. Em `use-prices.ts`:

```js
salePrice         = getPriceWithDiscount(price, availableExtraDiscount)  // apply_discount: cupom, UTM — client-only
priceWithDiscount = getPriceWithDiscount(salePrice, discountObject)      // desconto à vista
```

O preço exibido é `(preço × promoção async) × desconto à vista`. O do JSON-LD era `preço × desconto-do-preset`. Divergem sempre que há promoção ativa — que é exatamente o tráfego de Shopping com UTM, o caso que motiva ter preço na marcação.

## O guard

`scripts/modules-info-preset.ts` agora difere via `onStorefrontInit`, o mesmo mecanismo que `helpers/server-data.ts:28` já usa pro mesmo problema. Executa na hora se o global já existe, espera o evento de init caso contrário — o preset resolve com os settings reais nos dois caminhos. Independe da reversão: desarma a mina pro próximo `.astro` que encostar nesse grafo.

## Verificação

Reproduzido e conferido localmente com `BUILD_OUTPUT=static BUILD_MINIMAL=true npx astro build` em `packages/storefront` (o pacote tem `content/settings.json`, então chega no caminho que falha):

| estado | build | `index.html` + `~fallback/index.html` |
|---|---|---|
| `origin/main` | ✗ `TypeError: Cannot read properties of undefined (reading 'onLoad')` em `chunks/Picture_*.mjs:87`, `at BuildPipeline.retrieveSsrEntry` | não gerados |
| só o guard, com o #788 de pé | ✓ | gerados |
| este PR | ✓ | gerados |

A linha do meio também mostra que o guard não deixa o preset vazio — o build passa com o `getPriceWithDiscount` ainda importado pelo `BaseHead`.

## Fica em aberto

O problema de origem do #788 volta: o feed e a landing page podem divergir pro Merchant Center. Vale notar que `feeds/src/firebase/render-catalog.ts` tira o desconto de `req.query.discount` (fração na URL do feed), **fonte diferente** do `settings.modules.list_payments.discount_option` — alinhar arredondamento não alinharia os preços. Se for pra ter preço no JSON-LD, ou os dois lados concordam num desconto conhecível no servidor, ou a marcação é atualizada no cliente depois que o `modules-info` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSDkcNHVd1K9iWBRJTXznL
