### PR TITLE
fix(analytics): Send customer-facing order number to Awin, not internal id

### DIFF
--- a/packages/ssr/src/lib/analytics/send-to-awin.ts
+++ b/packages/ssr/src/lib/analytics/send-to-awin.ts
@@ -45,8 +45,7 @@ const sendToAwin = async ({
     if (!params?.transaction_id) return;
     const voucher = params.coupon;
     const awinOrder: Record<string, any> = {
-      // Awin wants the customer-visible order number, not our internal _id
-      orderReference: params.order_number || params.transaction_id,
+      orderReference: String(params.order_number || params.transaction_id),
       channel: validChannels.has(channel) ? channel : 'aw',
       awc,
       voucher,

--- a/packages/ssr/src/lib/analytics/send-to-awin.ts
+++ b/packages/ssr/src/lib/analytics/send-to-awin.ts
@@ -45,7 +45,8 @@ const sendToAwin = async ({
     if (!params?.transaction_id) return;
     const voucher = params.coupon;
     const awinOrder: Record<string, any> = {
-      orderReference: params.transaction_id,
+      // Awin wants the customer-visible order number, not our internal _id
+      orderReference: params.order_number || params.transaction_id,
       channel: validChannels.has(channel) ? channel : 'aw',
       awc,
       voucher,

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -92,8 +92,11 @@ const watchAppRoutes = () => {
               //
             }
           }
-          const { amount } = (order || (window as any).storefrontApp) as {
+          const { amount, number: orderNumber } = (
+            order || (window as any).storefrontApp
+          ) as {
             amount?: Orders['amount'],
+            number?: Orders['number'],
           };
           const params: Gtag.EventParams & PurchaseExtraParams = {
             transaction_id: orderId,
@@ -103,6 +106,9 @@ const watchAppRoutes = () => {
               ? order.extra_discount?.discount_coupon
               : getCouponApplied(),
           };
+          if (orderNumber) {
+            params.order_number = orderNumber;
+          }
           if (amount) {
             if (amount.freight !== undefined) {
               params.shipping = fixMoneyValue(amount.freight);
@@ -156,7 +162,11 @@ const watchAppRoutes = () => {
             params.shipping_delivery_days = days;
           }
           emitGtagEvent('purchase', params, paramsToHash);
-          emitAwinFallbackPixel(orderId, params.value as number, params.coupon);
+          emitAwinFallbackPixel(
+            params.order_number ? String(params.order_number) : orderId,
+            params.value as number,
+            params.coupon,
+          );
           localStorage.setItem('gtag.orderIdSent', orderId);
         }
         isPurchaseSent = true;

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -81,7 +81,7 @@ const watchAppRoutes = () => {
     };
 
     let isPurchaseSent = false;
-    const emitPurchase = (orderId: string, orderJson?: string) => {
+    const emitPurchase = (orderId: string, routeOrderNumber?: string, orderJson?: string) => {
       if (!isPurchaseSent) {
         if (localStorage.getItem('gtag.orderIdSent') !== orderId) {
           let order: Orders | undefined;
@@ -92,12 +92,16 @@ const watchAppRoutes = () => {
               //
             }
           }
-          const { amount, number: orderNumber } = (
+          const { amount, number: bodyOrderNumber } = (
             order || (window as any).storefrontApp
           ) as {
             amount?: Orders['amount'],
             number?: Orders['number'],
           };
+          /* Order number is a route param (`/confirmation/:id?/:number?/:json?`)
+          since the first navigation, while the order body may take longer to
+          load — or never arrive, on the timed out fallback below. */
+          const orderNumber = bodyOrderNumber || Number(routeOrderNumber) || undefined;
           const params: Gtag.EventParams & PurchaseExtraParams = {
             transaction_id: orderId,
             value: fixMoneyValue(amount?.total || shoppingCart.subtotal || 0),
@@ -192,10 +196,10 @@ const watchAppRoutes = () => {
         case 'confirmation':
           clearTimeout(emitPurchaseTimer);
           if (params.json) {
-            emitPurchase(params.id, decodeURIComponent(params.json));
+            emitPurchase(params.id, params.number, decodeURIComponent(params.json));
           } else {
             emitPurchaseTimer = setTimeout(() => {
-              emitPurchase(params.id);
+              emitPurchase(params.id, params.number);
             }, 1500);
           }
           break;

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -31,12 +31,12 @@ import utm from '@@sf/scripts/session-utm';
 
 // https://help.awin.com/developers/docs/fall-back-conversion-pixel
 // Awin prioritizes one tracking method per order ref, no double-count with the S2S call
-const emitAwinFallbackPixel = (orderId: string, amount: number, coupon?: string) => {
+const emitAwinFallbackPixel = (orderRef: string, amount: number, coupon?: string) => {
   if (!window.AWIN_ADVERTISER_ID || !trackingIds.awc) return;
   const src = 'https://www.awin1.com/sread.img'
     + `?tt=ns&tv=2&merchant=${encodeURIComponent(window.AWIN_ADVERTISER_ID)}`
     + `&amount=${amount}&cr=${encodeURIComponent(window.ECOM_CURRENCY)}`
-    + `&ref=${encodeURIComponent(orderId)}`
+    + `&ref=${encodeURIComponent(orderRef)}`
     + `&parts=${encodeURIComponent(`DEFAULT:${amount}`)}`
     + `&vc=${encodeURIComponent(coupon || '')}`
     + `&ch=${encodeURIComponent(trackingIds.awin_channel || 'aw')}`
@@ -81,7 +81,11 @@ const watchAppRoutes = () => {
     };
 
     let isPurchaseSent = false;
-    const emitPurchase = (orderId: string, routeOrderNumber?: string, orderJson?: string) => {
+    const emitPurchase = (
+      orderId: string,
+      routeOrderNumber?: string | number,
+      orderJson?: string,
+    ) => {
       if (!isPurchaseSent) {
         if (localStorage.getItem('gtag.orderIdSent') !== orderId) {
           let order: Orders | undefined;
@@ -98,9 +102,6 @@ const watchAppRoutes = () => {
             amount?: Orders['amount'],
             number?: Orders['number'],
           };
-          /* Order number is a route param (`/confirmation/:id?/:number?/:json?`)
-          since the first navigation, while the order body may take longer to
-          load — or never arrive, on the timed out fallback below. */
           const orderNumber = bodyOrderNumber || Number(routeOrderNumber) || undefined;
           const params: Gtag.EventParams & PurchaseExtraParams = {
             transaction_id: orderId,

--- a/packages/storefront/src/lib/state/use-analytics.ts
+++ b/packages/storefront/src/lib/state/use-analytics.ts
@@ -67,6 +67,7 @@ export const GTAG_EVENT_TYPE = 'GtagEvent';
 
 export type PurchaseExtraParams = {
   buyer_id?: string;
+  order_number?: number;
   shipping_addr_province_code?: string;
   shipping_addr_country_code?: string;
   shipping_delivery_days?: number;


### PR DESCRIPTION
## Summary
- Awin sent feedback confirming they received our Conversion API request, but asked to confirm whether the end customer sees the id we sent (`6a71d509db10ce09297ee220`, our internal MongoDB `_id`) or if they need the order number instead (`#3043734`) — they want the customer-visible order number.
- `orderReference` in `send-to-awin.ts` (S2S Conversion API) and the `ref` param of the fallback pixel in `vbeta-app.ts` now use `order_number` (falls back to the internal id if the order number isn't available for some reason).

## Test plan
- [x] `npx eslint` on the 3 changed files — clean (0 errors)
- [x] `npx tsc --noEmit` on `packages/ssr` and `packages/storefront` — no errors introduced by this change
- [ ] Manual purchase test + confirm with Awin that the new `orderReference`/`ref` matches the order number they expect

🤖 Generated with [Claude Code](https://claude.com/claude-code)