### PR TITLE
fix(storefront): Fix loyalty points not showing at checkout when store has discount preset

### DIFF
--- a/packages/storefront/src/lib/state/modules-info.ts
+++ b/packages/storefront/src/lib/state/modules-info.ts
@@ -81,11 +81,10 @@ if (!import.meta.env.SSR) {
   const fetchInfo = () => {
     const modulesToFetch: { modName: ModuleApiEndpoint, reqOptions?: any }[] = [];
     (['list_payments', 'calculate_shipping'] as const).forEach((modName) => {
-      if (!Object.keys(modulesInfo[modName]).length) {
-        modulesToFetch.push({ modName });
-      } else {
+      if (Object.keys(modulesInfo[modName]).length) {
         modulesInfoEmitter.emit(modName, modulesInfo[modName]);
       }
+      modulesToFetch.push({ modName });
     });
     if (Object.keys(utm).length || sessionCoupon) {
       const { apiContext } = globalThis.$storefront;

--- a/packages/storefront/src/lib/state/modules-info.ts
+++ b/packages/storefront/src/lib/state/modules-info.ts
@@ -33,8 +33,19 @@ const modulesInfo = reactive<{
     available_extra_discount?: ApplyDiscountResponse['available_extra_discount'],
   },
 }>(emptyInfo);
+const infoPreset: { [modName: string]: Record<string, any> } = {};
 loadingGlobalInfoPreset.then((modulesInfoPreset) => {
-  Object.assign(modulesInfo, modulesInfoPreset);
+  Object.keys(modulesInfoPreset).forEach((modName) => {
+    // Must copy, assigning the preset objects themselves would alias
+    // `window.$storefront.modulesInfoPreset` and empty it on refresh
+    infoPreset[modName] = { ...modulesInfoPreset[modName] };
+    Object.keys(infoPreset[modName]).forEach((field) => {
+      // Preset is the baseline only, persisted (API sourced) info wins
+      if (modulesInfo[modName][field] === undefined) {
+        modulesInfo[modName][field] = infoPreset[modName][field];
+      }
+    });
+  });
 });
 const modulesInfoEmitter = mitt();
 
@@ -119,9 +130,6 @@ if (!import.meta.env.SSR) {
       fetchModule(modName, reqOptions)
         .then(async (response) => {
           if (response.ok) {
-            Object.keys(modulesInfo[modName]).forEach((key) => {
-              delete modulesInfo[modName][key];
-            });
             const modInfo = {};
             const { result } = await response.json();
             if (Array.isArray(result)) {
@@ -183,7 +191,15 @@ if (!import.meta.env.SSR) {
                 }
               });
             }
-            Object.assign(modulesInfo[modName], modInfo);
+            // Keep preset fields the response didn't bring: an app returning
+            // error must not erase what's set on storefront settings
+            const nextInfo = { ...infoPreset[modName], ...modInfo };
+            Object.keys(modulesInfo[modName]).forEach((key) => {
+              if (nextInfo[key] === undefined) {
+                delete modulesInfo[modName][key];
+              }
+            });
+            Object.assign(modulesInfo[modName], nextInfo);
             sessionStorage.setItem(storageKey, JSON.stringify({
               ...modulesInfo,
               __timestamp: Date.now(),

--- a/packages/storefront/src/lib/state/modules-info.ts
+++ b/packages/storefront/src/lib/state/modules-info.ts
@@ -35,12 +35,11 @@ const modulesInfo = reactive<{
 }>(emptyInfo);
 const infoPreset: { [modName: string]: Record<string, any> } = {};
 loadingGlobalInfoPreset.then((modulesInfoPreset) => {
+  // Copied and gap filled: must not alias (and later empty)
+  // `window.$storefront.modulesInfoPreset`, nor override persisted info
   Object.keys(modulesInfoPreset).forEach((modName) => {
-    // Must copy, assigning the preset objects themselves would alias
-    // `window.$storefront.modulesInfoPreset` and empty it on refresh
     infoPreset[modName] = { ...modulesInfoPreset[modName] };
     Object.keys(infoPreset[modName]).forEach((field) => {
-      // Preset is the baseline only, persisted (API sourced) info wins
       if (modulesInfo[modName][field] === undefined) {
         modulesInfo[modName][field] = infoPreset[modName][field];
       }
@@ -74,12 +73,17 @@ export const fetchModule: FetchModule = (modName, reqOptions) => {
 
 if (!import.meta.env.SSR) {
   const storageKey = 'MODULES_INFO';
+  const fetchedModules = new Set<ModuleApiEndpoint>();
   const sessionJson = sessionStorage.getItem(storageKey);
   if (sessionJson) {
     try {
       const persistedValue = JSON.parse(sessionJson);
       if (persistedValue.__timestamp >= Date.now() - 1000 * 60 * 5) {
         delete persistedValue.__timestamp;
+        if (Array.isArray(persistedValue.__fetched)) {
+          persistedValue.__fetched.forEach((modName) => fetchedModules.add(modName));
+        }
+        delete persistedValue.__fetched;
         Object.assign(modulesInfo, persistedValue);
       } else {
         sessionStorage.removeItem(storageKey);
@@ -92,10 +96,18 @@ if (!import.meta.env.SSR) {
   const fetchInfo = () => {
     const modulesToFetch: { modName: ModuleApiEndpoint, reqOptions?: any }[] = [];
     (['list_payments', 'calculate_shipping'] as const).forEach((modName) => {
-      if (Object.keys(modulesInfo[modName]).length) {
+      const isInfoSet = Object.keys(modulesInfo[modName]).length > 0;
+      if (isInfoSet) {
         modulesInfoEmitter.emit(modName, modulesInfo[modName]);
       }
-      modulesToFetch.push({ modName });
+      // Preset covers `calculate_shipping` (single field), but `list_payments`
+      // may still miss `loyalty_points_programs` and others
+      const canSkipRequest = modName === 'calculate_shipping'
+        ? isInfoSet
+        : fetchedModules.has(modName);
+      if (!canSkipRequest) {
+        modulesToFetch.push({ modName });
+      }
     });
     if (Object.keys(utm).length || sessionCoupon) {
       const { apiContext } = globalThis.$storefront;
@@ -191,8 +203,7 @@ if (!import.meta.env.SSR) {
                 }
               });
             }
-            // Keep preset fields the response didn't bring: an app returning
-            // error must not erase what's set on storefront settings
+            // Preset must survive a response missing the field (app error)
             const nextInfo = { ...infoPreset[modName], ...modInfo };
             Object.keys(modulesInfo[modName]).forEach((key) => {
               if (nextInfo[key] === undefined) {
@@ -200,9 +211,13 @@ if (!import.meta.env.SSR) {
               }
             });
             Object.assign(modulesInfo[modName], nextInfo);
+            if (Object.keys(modInfo).length) {
+              fetchedModules.add(modName);
+            }
             sessionStorage.setItem(storageKey, JSON.stringify({
               ...modulesInfo,
               __timestamp: Date.now(),
+              __fetched: [...fetchedModules],
             }));
             modulesInfoEmitter.emit(modName, modulesInfo[modName]);
           }


### PR DESCRIPTION
## Summary

- Stores with `discount_option` configured in modules settings (e.g. PIX discount) had `modulesInfo.list_payments` pre-populated from the preset
- `fetchInfo` was skipping the API call when any preset data existed, so `loyalty_points_programs` returned by the loyalty app was never merged
- `waitStorefrontInfo('list_payments', 'loyalty_points_programs')` in `PointsApplier` never resolved — loyalty points toggle was never rendered

**Root cause commit:** a3ab982da

**Fix:** always fetch from the API; emit preset/cached data immediately as initial value while the API call completes.

## Test plan
- [ ] Store with PIX/discount preset: confirm loyalty points toggle appears in checkout after selecting shipping
- [ ] Confirm `window.storefront?.info?.list_payments?.loyalty_points_programs` is populated after checkout load