### PR TITLE
fix(analytics): Ensure Awin conversions carry customer-facing order number and net amount

### DIFF
--- a/packages/apps/asaas/src/asaas-create-transaction.ts
+++ b/packages/apps/asaas/src/asaas-create-transaction.ts
@@ -95,7 +95,7 @@ export default async (modBody: AppModuleBody<'create_transaction'>) => {
       'externalReference': orderId,
       'description': `Pedido ${orderNumber} ${domain}`,
       'callback': domain
-        ? { 'successUrl': `https://${domain}/app/#/confirmation/${orderId}/` }
+        ? { 'successUrl': `https://${domain}/app/#/confirmation/${orderId}/${orderNumber}` }
         : undefined,
     };
     if (paymentMethod.code === 'account_deposit') {

--- a/packages/apps/asaas/src/asaas-create-transaction.ts
+++ b/packages/apps/asaas/src/asaas-create-transaction.ts
@@ -95,7 +95,10 @@ export default async (modBody: AppModuleBody<'create_transaction'>) => {
       'externalReference': orderId,
       'description': `Pedido ${orderNumber} ${domain}`,
       'callback': domain
-        ? { 'successUrl': `https://${domain}/app/#/confirmation/${orderId}/${orderNumber}` }
+        ? {
+          'successUrl': `https://${domain}/app/#/confirmation/${orderId}`
+            + (orderNumber ? `/${orderNumber}` : ''),
+        }
         : undefined,
     };
     if (paymentMethod.code === 'account_deposit') {

--- a/packages/modules/src/firebase/functions-checkout/handle-order-transaction.ts
+++ b/packages/modules/src/firebase/functions-checkout/handle-order-transaction.ts
@@ -13,17 +13,26 @@ const newOrder = async (orderBody: OrderSet) => {
   try {
     const orderId = (await api.post('orders', orderBody)).data._id;
     return new Promise<{ order: Orders | null, err?: any }>((resolve) => {
-      setTimeout(async () => {
+      let attempts = 0;
+      const readFullOrder = async () => {
+        attempts += 1;
         try {
           const { data: order } = await api.get(`orders/${orderId}`, {
             headers: { 'x-primary-db': 'true' },
           });
+          // The order number is set asynchronously and may not be ready yet,
+          // without it the storefront can't reference the order for the customer
+          if (!order.number && attempts <= 3) {
+            setTimeout(readFullOrder, 400 * attempts);
+            return;
+          }
           resolve({ order });
         } catch (err: any) {
           logger.error(err);
           resolve({ order: null, err });
         }
-      }, 400);
+      };
+      setTimeout(readFullOrder, 400);
     });
   } catch (err: any) {
     if (err.message === 'fetch failed') {

--- a/packages/modules/src/firebase/functions-checkout/handle-order-transaction.ts
+++ b/packages/modules/src/firebase/functions-checkout/handle-order-transaction.ts
@@ -20,6 +20,10 @@ const newOrder = async (orderBody: OrderSet) => {
         try {
           const { data: order } = await api.get(`orders/${orderId}`, {
             headers: { 'x-primary-db': 'true' },
+            // Rereads are best-effort just for the order number, only the first
+            // read decides whether the checkout can go on, so it keeps the
+            // client defaults and the reread cost can't pile up on a slow API
+            ...(attempts > 1 ? { timeout: 1500, maxRetries: 0 } : null),
           });
           lastOrderRead = order;
           // The order number is set asynchronously and may not be ready yet,
@@ -29,17 +33,32 @@ const newOrder = async (orderBody: OrderSet) => {
             return;
           }
           if (!order.number) {
-            logger.warn(`Order ${orderId} number still unset after ${attempts} reads`);
+            logger.warn(`Order ${orderId} number still unset after ${attempts} reads`, {
+              orderId,
+              attempts,
+            });
+          } else {
+            // Logged on every order to tell whether the rereads are the rule
+            // or the tail, the number of attempts must be tuned with data
+            logger.info(`Order ${orderId} number read on attempt ${attempts}`, {
+              orderId,
+              attempts,
+            });
           }
           resolve({ order });
         } catch (err: any) {
-          logger.error(err);
           // The order does exist, don't fail the checkout over a transient
           // read error when a previous read already succeeded
           if (lastOrderRead) {
+            logger.warn(`Failed rereading order ${orderId} on attempt ${attempts}`, {
+              orderId,
+              attempts,
+              err,
+            });
             resolve({ order: lastOrderRead });
             return;
           }
+          logger.error(err);
           resolve({ order: null, err });
         }
       };

--- a/packages/modules/src/firebase/functions-checkout/handle-order-transaction.ts
+++ b/packages/modules/src/firebase/functions-checkout/handle-order-transaction.ts
@@ -14,21 +14,32 @@ const newOrder = async (orderBody: OrderSet) => {
     const orderId = (await api.post('orders', orderBody)).data._id;
     return new Promise<{ order: Orders | null, err?: any }>((resolve) => {
       let attempts = 0;
+      let lastOrderRead: Orders | null = null;
       const readFullOrder = async () => {
         attempts += 1;
         try {
           const { data: order } = await api.get(`orders/${orderId}`, {
             headers: { 'x-primary-db': 'true' },
           });
+          lastOrderRead = order;
           // The order number is set asynchronously and may not be ready yet,
           // without it the storefront can't reference the order for the customer
           if (!order.number && attempts <= 3) {
             setTimeout(readFullOrder, 400 * attempts);
             return;
           }
+          if (!order.number) {
+            logger.warn(`Order ${orderId} number still unset after ${attempts} reads`);
+          }
           resolve({ order });
         } catch (err: any) {
           logger.error(err);
+          // The order does exist, don't fail the checkout over a transient
+          // read error when a previous read already succeeded
+          if (lastOrderRead) {
+            resolve({ order: lastOrderRead });
+            return;
+          }
           resolve({ order: null, err });
         }
       };

--- a/packages/ssr/src/lib/analytics/send-to-awin.ts
+++ b/packages/ssr/src/lib/analytics/send-to-awin.ts
@@ -37,11 +37,17 @@ const fetchOrderFallback = async (orderId: string) => {
   try {
     const { data: order } = await api.get(`orders/${orderId as Orders['_id']}`, {
       fields: ['number', 'amount', 'extra_discount'] as const,
+      headers: { 'x-primary-db': 'true' },
+      // Keep this read within the SSR function time budget, it must not
+      // delay or starve the other analytics providers in the same batch
+      timeout: 3000,
+      maxRetries: 0,
     });
     return order;
   } catch (err: any) {
-    logger.warn(`Failed reading order ${orderId} for Awin reference`, {
-      status: err.statusCode || err.response?.status,
+    logger.warn(`Failed reading order ${orderId} for Awin conversion`, {
+      err,
+      status: err.statusCode,
     });
     return null;
   }
@@ -62,7 +68,6 @@ const sendToAwin = async ({
   const awinOrders: Array<Record<string, any>> = [];
   for (let i = 0; i < purchaseEvents.length; i++) {
     const { params } = purchaseEvents[i];
-    // eslint-disable-next-line no-continue
     if (!params?.transaction_id) continue;
     let orderNumber = params.order_number;
     let voucher = params.coupon;
@@ -70,11 +75,14 @@ const sendToAwin = async ({
     let grossValue = Number(params.value) || 0;
     let shipping = Number(params.shipping) || 0;
     let tax = Number(params.tax) || 0;
-    if (!orderNumber) {
+    // The client event may miss the order number (external payment redirects)
+    // and/or the exact amounts (no order body on the confirmation route, value
+    // falls back to cart subtotal), read the order whenever any is absent
+    if (!orderNumber || params.shipping === undefined) {
       // eslint-disable-next-line no-await-in-loop
       const order = await fetchOrderFallback(`${params.transaction_id}`);
       if (order) {
-        orderNumber = order.number;
+        if (order.number) orderNumber = order.number;
         if (order.amount) {
           grossValue = Number(order.amount.total) || grossValue;
           shipping = Number(order.amount.freight) || 0;
@@ -82,6 +90,11 @@ const sendToAwin = async ({
         }
         if (!voucher) voucher = order.extra_discount?.discount_coupon;
       }
+    }
+    if (!orderNumber) {
+      logger.warn(
+        `Awin conversion falling back to internal ID for order ${params.transaction_id}`,
+      );
     }
     const netAmount = Math.max(
       Math.round((grossValue - shipping - tax) * 100) / 100,

--- a/packages/ssr/src/lib/analytics/send-to-awin.ts
+++ b/packages/ssr/src/lib/analytics/send-to-awin.ts
@@ -20,10 +20,14 @@ const awinAxios = AWIN_ADVERTISER_ID && AWIN_API_KEY
   })
   : null;
 
-// Expected AwinChannelCookie values — Awin docs mandate 'aw' as the fallback
-const validChannels = new Set([
-  'aw', 'ppcgeneric', 'ppcbrand', 'display', 'social', 'Other', 'Organic', 'direct',
-]);
+// Awin doesn't enumerate accepted channels, the value is free-form and must
+// match the `ch` the fallback pixel sends for the same order reference,
+// 'aw' is the mandated fallback
+// https://help.awin.com/developers/docs/channel-parameter
+const parseChannel = (channel: unknown) => {
+  if (typeof channel !== 'string') return 'aw';
+  return channel.toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 20) || 'aw';
+};
 
 // Awin forbids the pipe character in id/name/sku/category basket fields
 const stripPipes = (value: unknown) => (
@@ -102,7 +106,7 @@ const sendToAwin = async ({
     );
     const awinOrder: Record<string, any> = {
       orderReference: String(orderNumber || params.transaction_id),
-      channel: validChannels.has(channel) ? channel : 'aw',
+      channel: parseChannel(channel),
       awc,
       voucher,
       amount: netAmount,

--- a/packages/ssr/src/lib/analytics/send-to-awin.ts
+++ b/packages/ssr/src/lib/analytics/send-to-awin.ts
@@ -1,5 +1,7 @@
+import type { Orders } from '@cloudcommerce/types';
 import type { AnalyticsEvent } from './send-analytics-events';
 import config, { logger } from '@cloudcommerce/firebase/lib/config';
+import api from '@cloudcommerce/api';
 import axios from 'axios';
 
 // https://help.awin.com/apidocs/conversion-api
@@ -28,6 +30,23 @@ const stripPipes = (value: unknown) => (
   typeof value === 'string' ? value.replace(/\|/g, '') : value
 );
 
+// Customers coming back from external payment pages land on the confirmation
+// route without the order number, so the purchase event may miss it
+const fetchOrderFallback = async (orderId: string) => {
+  if (!/^[0-9a-f]{24}$/.test(orderId)) return null;
+  try {
+    const { data: order } = await api.get(`orders/${orderId as Orders['_id']}`, {
+      fields: ['number', 'amount', 'extra_discount'] as const,
+    });
+    return order;
+  } catch (err: any) {
+    logger.warn(`Failed reading order ${orderId} for Awin reference`, {
+      status: err.statusCode || err.response?.status,
+    });
+    return null;
+  }
+};
+
 const sendToAwin = async ({
   events,
   awc,
@@ -41,19 +60,35 @@ const sendToAwin = async ({
   const purchaseEvents = events.filter((ev) => ev.name === 'purchase');
   if (!purchaseEvents.length) return;
   const awinOrders: Array<Record<string, any>> = [];
-  purchaseEvents.forEach(({ params }) => {
-    if (!params?.transaction_id) return;
-    const voucher = params.coupon;
+  for (let i = 0; i < purchaseEvents.length; i++) {
+    const { params } = purchaseEvents[i];
+    // eslint-disable-next-line no-continue
+    if (!params?.transaction_id) continue;
+    let orderNumber = params.order_number;
+    let voucher = params.coupon;
     // Awin expects the commissionable amount without freight and taxes
-    const grossValue = Number(params.value) || 0;
+    let grossValue = Number(params.value) || 0;
+    let shipping = Number(params.shipping) || 0;
+    let tax = Number(params.tax) || 0;
+    if (!orderNumber) {
+      // eslint-disable-next-line no-await-in-loop
+      const order = await fetchOrderFallback(`${params.transaction_id}`);
+      if (order) {
+        orderNumber = order.number;
+        if (order.amount) {
+          grossValue = Number(order.amount.total) || grossValue;
+          shipping = Number(order.amount.freight) || 0;
+          tax = Number(order.amount.tax) || 0;
+        }
+        if (!voucher) voucher = order.extra_discount?.discount_coupon;
+      }
+    }
     const netAmount = Math.max(
-      Math.round(
-        (grossValue - (Number(params.shipping) || 0) - (Number(params.tax) || 0)) * 100,
-      ) / 100,
+      Math.round((grossValue - shipping - tax) * 100) / 100,
       0,
     );
     const awinOrder: Record<string, any> = {
-      orderReference: String(params.order_number || params.transaction_id),
+      orderReference: String(orderNumber || params.transaction_id),
       channel: validChannels.has(channel) ? channel : 'aw',
       awc,
       voucher,
@@ -74,7 +109,7 @@ const sendToAwin = async ({
       })),
     };
     awinOrders.push(awinOrder);
-  });
+  }
   if (awinOrders.length) {
     const data = { orders: awinOrders };
     if (DEBUG_SERVER_ANALYTICS?.toLowerCase() === 'true') {

--- a/packages/ssr/src/lib/analytics/send-to-awin.ts
+++ b/packages/ssr/src/lib/analytics/send-to-awin.ts
@@ -44,16 +44,24 @@ const sendToAwin = async ({
   purchaseEvents.forEach(({ params }) => {
     if (!params?.transaction_id) return;
     const voucher = params.coupon;
+    // Awin expects the commissionable amount without freight and taxes
+    const grossValue = Number(params.value) || 0;
+    const netAmount = Math.max(
+      Math.round(
+        (grossValue - (Number(params.shipping) || 0) - (Number(params.tax) || 0)) * 100,
+      ) / 100,
+      0,
+    );
     const awinOrder: Record<string, any> = {
       orderReference: String(params.order_number || params.transaction_id),
       channel: validChannels.has(channel) ? channel : 'aw',
       awc,
       voucher,
-      amount: params.value,
+      amount: netAmount,
       currency: params.currency || config.get().currency,
       commissionGroups: [{
         code: 'DEFAULT',
-        amount: params.value,
+        amount: netAmount,
       }],
       basket: params.items?.map((item: Record<string, any>) => ({
         id: stripPipes(item.object_id || item.item_id),

--- a/packages/storefront/client.d.ts
+++ b/packages/storefront/client.d.ts
@@ -35,6 +35,7 @@ interface Window {
   GA_TRACKING_ID?: string;
   GOOGLE_ADS_ID?: string;
   AWIN_ADVERTISER_ID?: string;
+  AWIN_S2S_ENABLED?: boolean;
   CMS_CUSTOM_CONFIG?: Record<string, any>;
   CMS_SSO_URL?: string | null;
   CMS_REPO_BASE_DIR?: string;

--- a/packages/storefront/src/analytics/set-tracking-ids.ts
+++ b/packages/storefront/src/analytics/set-tracking-ids.ts
@@ -76,7 +76,12 @@ export const getTrackingIds = (
         switch (cookieName) {
           case '_fbp': trackingIds.fbp = value; return;
           case '_fbc': trackingIds.fbc = value; return;
-          case 'AwinChannelCookie': trackingIds.awin_channel = value; return;
+          case 'AwinChannelCookie':
+            // Normalized at the source so the fallback pixel and the server
+            // side conversion send the exact same channel for one order
+            trackingIds.awin_channel = value
+              .toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 20) || undefined;
+            return;
           default:
         }
         if (cookieName.startsWith('_ga')) {

--- a/packages/storefront/src/lib/layouts/BaseHead.astro
+++ b/packages/storefront/src/lib/layouts/BaseHead.astro
@@ -95,6 +95,7 @@ window.GIT_BRANCH = '${import.meta.env.GIT_BRANCH || ''}';
 window.GIT_REPO = '${import.meta.env.GIT_REPO || import.meta.env.GITHUB_REPO || ''}';
 window.GCLOUD_PROJECT = '${import.meta.env.GCLOUD_PROJECT || ''}';
 window.AWIN_ADVERTISER_ID = '${import.meta.env.AWIN_ADVERTISER_ID || ''}';
+window.AWIN_S2S_ENABLED = ${!!(import.meta.env.AWIN_ADVERTISER_ID && import.meta.env.AWIN_API_KEY)};
 window.$storefront = ${JSON.stringify({ settings, data: {} })};`;
 if (apiContext.error) {
   const { message, statusCode } = apiContext.error;

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -167,15 +167,21 @@ const watchAppRoutes = () => {
             params.shipping_delivery_days = days;
           }
           emitGtagEvent('purchase', params, paramsToHash);
-          // Skip the pixel without the customer-facing number: the S2S call resolves
-          // it from the API, and a pixel with a mismatched ref would double-count
-          if (params.order_number) {
+          // With the S2S call active the pixel only fires when the client
+          // has the customer-facing number AND the real order amounts: a
+          // pixel with mismatched ref or amount could win Awin's dedup by
+          // reference over the accurate S2S conversion. Without S2S the
+          // pixel is the only channel, so it always fires falling back to
+          // the internal order ID and cart subtotal (legacy behavior)
+          const canEmitAwinPixel = !window.AWIN_S2S_ENABLED
+            || (!!params.order_number && params.shipping !== undefined);
+          if (canEmitAwinPixel) {
             // Awin expects the commissionable amount without freight and taxes
             const awinAmount = Math.max(fixMoneyValue(
               Number(params.value) - (Number(params.shipping) || 0) - (Number(params.tax) || 0),
             ), 0);
             emitAwinFallbackPixel(
-              String(params.order_number),
+              params.order_number ? String(params.order_number) : orderId,
               awinAmount,
               params.coupon,
             );

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -167,9 +167,13 @@ const watchAppRoutes = () => {
             params.shipping_delivery_days = days;
           }
           emitGtagEvent('purchase', params, paramsToHash);
+          // Awin expects the commissionable amount without freight and taxes
+          const awinAmount = Math.max(fixMoneyValue(
+            (params.value as number) - (params.shipping || 0) - (params.tax || 0),
+          ), 0);
           emitAwinFallbackPixel(
             params.order_number ? String(params.order_number) : orderId,
-            params.value as number,
+            awinAmount,
             params.coupon,
           );
           localStorage.setItem('gtag.orderIdSent', orderId);

--- a/packages/storefront/src/lib/scripts/vbeta-app.ts
+++ b/packages/storefront/src/lib/scripts/vbeta-app.ts
@@ -167,15 +167,19 @@ const watchAppRoutes = () => {
             params.shipping_delivery_days = days;
           }
           emitGtagEvent('purchase', params, paramsToHash);
-          // Awin expects the commissionable amount without freight and taxes
-          const awinAmount = Math.max(fixMoneyValue(
-            (params.value as number) - (params.shipping || 0) - (params.tax || 0),
-          ), 0);
-          emitAwinFallbackPixel(
-            params.order_number ? String(params.order_number) : orderId,
-            awinAmount,
-            params.coupon,
-          );
+          // Skip the pixel without the customer-facing number: the S2S call resolves
+          // it from the API, and a pixel with a mismatched ref would double-count
+          if (params.order_number) {
+            // Awin expects the commissionable amount without freight and taxes
+            const awinAmount = Math.max(fixMoneyValue(
+              Number(params.value) - (Number(params.shipping) || 0) - (Number(params.tax) || 0),
+            ), 0);
+            emitAwinFallbackPixel(
+              String(params.order_number),
+              awinAmount,
+              params.coupon,
+            );
+          }
           localStorage.setItem('gtag.orderIdSent', orderId);
         }
         isPurchaseSent = true;


### PR DESCRIPTION
Fixes the issues reported by Awin's affiliate team on Tia Sônia's integration testing:

**Wrong order reference (internal _id instead of customer-facing number)**

Awin's test order (nº 3044575, 2026-08-13) was received with the internal order ID. Traced via Firebase logs (DEBUG_SERVER_ANALYTICS): the purchase event reached the server without order_number. Two gaps allowed this:

- The order number is assigned asynchronously by the API, and checkout's single 400ms-delayed order read could respond before it was set — so the confirmation route, purchase event and Awin S2S all fell back to _id. Now the checkout retries the order read (up to 3 more times with backoff) until the number is available.
- As an authoritative safety net, the SSR analytics handler now fetches the order from the API whenever the purchase event misses order_number **or the exact amounts**, resolving the customer-facing number, exact amounts and coupon before posting to Awin's Conversion API.
- The client-side fallback pixel (sread.img) only fires, when the S2S call is configured, if the page has both the customer-facing number and the real order amounts — a pixel with a mismatched ref or amount could win Awin's dedup by reference over the accurate S2S conversion. Stores without the S2S API key keep the pixel as their only channel with legacy behavior.
- Asaas successUrl now carries the order number so customers returning from external payment pages land on the confirmation route with the full reference.

**Amount sent with freight included**

Awin expects the commissionable amount without freight and taxes. The S2S payload and the fallback pixel now send value − shipping − tax (falling back to the order's amount fields when fetched server-side).

---

**Scope note — the checkout order read retry fixes more than Awin:** `order.number` becomes `transactionBody.order_number` and feeds every payment gateway. Without it, Asaas/Woovi/GalaxPay/Pagar.me/Pagaleve rendered "Pedido undefined" on customer-facing charge descriptions (e.g. boleto). The retry (up to ~2.8s worst case) closes that silent degradation for all of them, not just Awin.

**Review follow-up (cea8b1bb1):**
- Server-side order fetch now also runs when the event misses the amounts (external payment returns carried the right ref with cart-subtotal values);
- That read uses `timeout: 3000` + `maxRetries: 0` + `x-primary-db` to stay within the SSR function's 10s budget without starving GA4/Meta/TikTok;
- Checkout retry keeps the last successfully-read order and resolves it on transient read errors, instead of failing (CKT701) an order that exists;
- Fallbacks to the internal order ID now `logger.warn` instead of degrading silently;
- Asaas successUrl omits the number segment when unset (no literal `undefined`); unused `eslint-disable no-continue` removed; fetch error logged with the error object.
