### PR TITLE
fix(emails): correct invoice_issued mail template key to `invoiceIssued`

### DIFF
--- a/packages/apps/emails/src/util/get-mail-templ.ts
+++ b/packages/apps/emails/src/util/get-mail-templ.ts
@@ -119,7 +119,7 @@ const getMailTempl = (typeOrStatus: MailMapKey) => {
       };
     case 'invoice_issued':
       return {
-        templ: 'invoice_issued',
+        templ: 'invoiceIssued',
         subject: {
           pt_br: 'Nota Fiscal do seu pedido',
           en_us: 'Invoice of your order',


### PR DESCRIPTION
## Bug

Every `invoice_issued` transactional email fails with:

```
TypeError: render is not a function
    at handleApiEvent (.../@cloudcommerce/app-emails/lib/event-to-emails.js)
```

`@ecomplus/transactional-mails` exports the invoice template as `invoiceIssued` (camelCase, like all the other status templates: `inProduction`, `readyForShipping`, ...), but `get-mail-templ.ts` returns `templ: 'invoice_issued'` for that status. `getMailRender` then resolves `transactionalMails['invoice_issued']` → `undefined`, and the render call throws. The event is retried a few times and finally dropped by age, so the customer/merchant never get the invoice email.

`templ` is typed as plain `string`, which is why the wrong key type-checked.

## Fix

One line: `templ: 'invoice_issued'` → `templ: 'invoiceIssued'`.

Observed in production on store 401207 (mundoquadri, 2026-08-24, order #6107): all other email types reach the SMTP provider normally, only `invoice_issued` throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)